### PR TITLE
Update models.py

### DIFF
--- a/likert_field/models.py
+++ b/likert_field/models.py
@@ -2,7 +2,8 @@
 from __future__ import unicode_literals
 
 from django.db import models
-from django.utils.encoding import force_text, python_2_unicode_compatible
+from django.utils.encoding import force_text
+from six import python_2_unicode_compatible
 from django.utils.six import string_types
 from django.utils.translation import ugettext_lazy as _
 

--- a/likert_field/widgets.py
+++ b/likert_field/widgets.py
@@ -6,8 +6,7 @@ from django.forms import widgets
 
 class LikertTextField(widgets.TextInput):
     """A Likert field represented as a text input"""
-
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, renderer=None):    
         """
         Returns this Widget rendered as HTML, as a Unicode string.
         """


### PR DESCRIPTION
fixes error: ImportError: cannot import name 'python_2_unicode_compatible' from 'django.utils.encoding' (/usr/local/lib/python3.8/dist-packages/django/utils/encoding.py)
when using django version > 3.